### PR TITLE
Enable chunk processing for logpac for large dataset

### DIFF
--- a/R/fitSpaNormNB.R
+++ b/R/fitSpaNormNB.R
@@ -304,7 +304,7 @@ fitNBGivenPsi <- function(Ysub, Wsub, psi, lambda.a, gmean = NULL, alpha = NULL,
   return(fit.nb)
 }
 
-normaliseLogPAC <- function(Y, scale.factor, fit.spanorm, chunk_size = 5000) {
+normaliseLogPAC <- function(Y, scale.factor, fit.spanorm, chunk.size = 5000) {
   # Winsorize dispersion parameters (small, done once)
   psi <- fit.spanorm$psi
   psi.max <- exp(median(log(psi)) + 3 * mad(log(psi)))
@@ -328,11 +328,11 @@ normaliseLogPAC <- function(Y, scale.factor, fit.spanorm, chunk_size = 5000) {
   gc(verbose = FALSE)
   
   # Process in chunks to avoid memory spike
-  n_chunks <- ceiling(n_spots / chunk_size)
+  n_chunks <- ceiling(n_spots / chunk.size)
   
   if (n_chunks > 1) {
-    message(sprintf("  Processing %d spots in %d chunks (chunk_size=%d) to manage memory", 
-                    n_spots, n_chunks, chunk_size))
+    message(sprintf("  Processing %d spots in %d chunks (chunk.size=%d) to manage memory", 
+                    n_spots, n_chunks, chunk.size))
   }
   
   # Pre-allocate final matrix (more memory-efficient than list)
@@ -341,8 +341,8 @@ normaliseLogPAC <- function(Y, scale.factor, fit.spanorm, chunk_size = 5000) {
   
   for (i in seq_len(n_chunks)) {
     # Define chunk indices
-    start_idx <- (i - 1) * chunk_size + 1
-    end_idx <- min(i * chunk_size, n_spots)
+    start_idx <- (i - 1) * chunk.size + 1
+    end_idx <- min(i * chunk.size, n_spots)
     chunk_idx <- start_idx:end_idx
     
     if (n_chunks > 1 && i %% max(1, floor(n_chunks / 10)) == 0) {

--- a/R/mainSpaNorm.R
+++ b/R/mainSpaNorm.R
@@ -18,6 +18,7 @@
 #' @param overwrite a logical, specifying whether to force recomputation and overwrite an existing fit (default FALSE). Note that if df.tps, batch, lambda.a, or gene.model are changed, the model is recomputed and overwritten.
 #' @param backend a character, specifying the backend to use for computations (default 'auto', see details). If 'gpu', GPU-based computations are used if available, otherwise CPU-based computations are used.
 #' @param verbose a logical, specifying whether to show update messages (default TRUE).
+#' @param chunksize a numeric, specifying the number of genes to process in each chunk when normalising data, only applies to logpac (default is 5000).
 #' @param ... other parameters fitting parameters.
 #' 
 #' @details SpaNorm works by first fitting a spatial regression model for library size to the data. Normalised data can then be computed using various adjustment approaches. When a negative binomial gene-model is used, the data can be adjusted using the following approaches: 'logpac', 'pearson', 'medbio', and 'meanbio'.
@@ -55,6 +56,7 @@ setGeneric("SpaNorm", function(
     overwrite = FALSE,
     backend = c("auto", "cpu", "gpu"),
     verbose = TRUE,
+    chunksize = 5000,
     ...) {
   standardGeneric("SpaNorm")
 })
@@ -63,7 +65,7 @@ setGeneric("SpaNorm", function(
 setMethod(
   "SpaNorm",
   signature("SpatialExperiment"),
-  function(spe, sample.p, gene.model, adj.method, scale.factor, df.tps, lambda.a, batch, tol, step.factor, maxit.nb, maxit.psi, overwrite, backend, verbose, ...) {
+  function(spe, sample.p, gene.model, adj.method, scale.factor, df.tps, lambda.a, batch, tol, step.factor, maxit.nb, maxit.psi, overwrite, backend, verbose, chunksize, ...) {
     checkSPE(spe)
     adj.method = match.arg(adj.method)
     gene.model = match.arg(gene.model)
@@ -103,7 +105,9 @@ setMethod(
       stop("'SpaNorm' fit should have at least one column representing 'biology'")
     }
     adj.fun = getAdjustmentFun(gene.model, adj.method)
-    normmat = adj.fun(emat, scale.factor, fit.spanorm)
+    if(adj.method %in% c("logpac", "auto")){
+      normmat = adj.fun(emat, scale.factor, fit.spanorm, chunksize)
+    } else normmat = adj.fun(emat, scale.factor, fit.spanorm)
     if ("logcounts" %in% SummarizedExperiment::assayNames(spe)) {
       warning("'logcounts' exists and will be overwritten")
     }
@@ -117,7 +121,7 @@ setMethod(
 setMethod(
   "SpaNorm",
   signature("Seurat"),
-  function(spe, sample.p, gene.model, adj.method, scale.factor, df.tps, lambda.a, batch, tol, step.factor, maxit.nb, maxit.psi, overwrite, backend, verbose, ...) {
+  function(spe, sample.p, gene.model, adj.method, scale.factor, df.tps, lambda.a, batch, tol, step.factor, maxit.nb, maxit.psi, overwrite, backend,verbose, chunksize, ...) {
     checkSeurat(spe)
     adj.method = match.arg(adj.method)
     gene.model = match.arg(gene.model)
@@ -159,7 +163,9 @@ setMethod(
       stop("'SpaNorm' fit should have at least one column representing 'biology'")
     }
     adj.fun = getAdjustmentFun(gene.model, adj.method)
-    normmat = adj.fun(emat, scale.factor, fit.spanorm)
+    if(adj.method %in% c("logpac", "auto")){
+      normmat = adj.fun(emat, scale.factor, fit.spanorm, chunksize)
+    } else normmat = adj.fun(emat, scale.factor, fit.spanorm)
     warning("'data' slot of Seurat assay will be overwritten with normalised values")
     spe = Seurat::SetAssayData(spe, assay = assay_name, layer = "data", new.data = methods::as(normmat, "dgCMatrix"))
 

--- a/R/mainSpaNorm.R
+++ b/R/mainSpaNorm.R
@@ -18,7 +18,7 @@
 #' @param overwrite a logical, specifying whether to force recomputation and overwrite an existing fit (default FALSE). Note that if df.tps, batch, lambda.a, or gene.model are changed, the model is recomputed and overwritten.
 #' @param backend a character, specifying the backend to use for computations (default 'auto', see details). If 'gpu', GPU-based computations are used if available, otherwise CPU-based computations are used.
 #' @param verbose a logical, specifying whether to show update messages (default TRUE).
-#' @param chunksize a numeric, specifying the number of genes to process in each chunk when normalising data, only applies to logpac (default is 5000).
+#' @param chunk.size a numeric, specifying the number of cells/spots to process in each chunk when normalising data, only applies to logpac (default is 5000).
 #' @param ... other parameters fitting parameters.
 #' 
 #' @details SpaNorm works by first fitting a spatial regression model for library size to the data. Normalised data can then be computed using various adjustment approaches. When a negative binomial gene-model is used, the data can be adjusted using the following approaches: 'logpac', 'pearson', 'medbio', and 'meanbio'.
@@ -56,7 +56,7 @@ setGeneric("SpaNorm", function(
     overwrite = FALSE,
     backend = c("auto", "cpu", "gpu"),
     verbose = TRUE,
-    chunksize = 5000,
+    chunk.size = 5000,
     ...) {
   standardGeneric("SpaNorm")
 })
@@ -65,7 +65,7 @@ setGeneric("SpaNorm", function(
 setMethod(
   "SpaNorm",
   signature("SpatialExperiment"),
-  function(spe, sample.p, gene.model, adj.method, scale.factor, df.tps, lambda.a, batch, tol, step.factor, maxit.nb, maxit.psi, overwrite, backend, verbose, chunksize, ...) {
+  function(spe, sample.p, gene.model, adj.method, scale.factor, df.tps, lambda.a, batch, tol, step.factor, maxit.nb, maxit.psi, overwrite, backend, verbose, chunk.size, ...) {
     checkSPE(spe)
     adj.method = match.arg(adj.method)
     gene.model = match.arg(gene.model)
@@ -106,7 +106,7 @@ setMethod(
     }
     adj.fun = getAdjustmentFun(gene.model, adj.method)
     if(adj.method %in% c("logpac", "auto")){
-      normmat = adj.fun(emat, scale.factor, fit.spanorm, chunksize)
+      normmat = adj.fun(emat, scale.factor, fit.spanorm, chunk.size)
     } else normmat = adj.fun(emat, scale.factor, fit.spanorm)
     if ("logcounts" %in% SummarizedExperiment::assayNames(spe)) {
       warning("'logcounts' exists and will be overwritten")
@@ -121,7 +121,7 @@ setMethod(
 setMethod(
   "SpaNorm",
   signature("Seurat"),
-  function(spe, sample.p, gene.model, adj.method, scale.factor, df.tps, lambda.a, batch, tol, step.factor, maxit.nb, maxit.psi, overwrite, backend,verbose, chunksize, ...) {
+  function(spe, sample.p, gene.model, adj.method, scale.factor, df.tps, lambda.a, batch, tol, step.factor, maxit.nb, maxit.psi, overwrite, backend,verbose, chunk.size, ...) {
     checkSeurat(spe)
     adj.method = match.arg(adj.method)
     gene.model = match.arg(gene.model)
@@ -164,7 +164,7 @@ setMethod(
     }
     adj.fun = getAdjustmentFun(gene.model, adj.method)
     if(adj.method %in% c("logpac", "auto")){
-      normmat = adj.fun(emat, scale.factor, fit.spanorm, chunksize)
+      normmat = adj.fun(emat, scale.factor, fit.spanorm, chunk.size)
     } else normmat = adj.fun(emat, scale.factor, fit.spanorm)
     warning("'data' slot of Seurat assay will be overwritten with normalised values")
     spe = Seurat::SetAssayData(spe, assay = assay_name, layer = "data", new.data = methods::as(normmat, "dgCMatrix"))

--- a/man/SpaNorm.Rd
+++ b/man/SpaNorm.Rd
@@ -23,7 +23,7 @@ SpaNorm(
   overwrite = FALSE,
   backend = c("auto", "cpu", "gpu"),
   verbose = TRUE,
-  chunksize = 5000,
+  chunk.size = 5000,
   ...
 )
 
@@ -44,7 +44,7 @@ SpaNorm(
   overwrite = FALSE,
   backend = c("auto", "cpu", "gpu"),
   verbose = TRUE,
-  chunksize = 5000,
+  chunk.size = 5000,
   ...
 )
 
@@ -65,7 +65,7 @@ SpaNorm(
   overwrite = FALSE,
   backend = c("auto", "cpu", "gpu"),
   verbose = TRUE,
-  chunksize = 5000,
+  chunk.size = 5000,
   ...
 )
 }
@@ -102,7 +102,7 @@ SpaNorm(
 
 \item{verbose}{a logical, specifying whether to show update messages (default TRUE).}
 
-\item{chunksize}{a numeric, specifying the number of genes to process in each chunk when normalising data, only applies to logpac (default is 5000).}
+\item{chunk.size}{a numeric, specifying the number of cells/spots to process in each chunk when normalising data, only applies to logpac (default is 5000).}
 
 \item{...}{other parameters fitting parameters.}
 }

--- a/man/SpaNorm.Rd
+++ b/man/SpaNorm.Rd
@@ -23,6 +23,7 @@ SpaNorm(
   overwrite = FALSE,
   backend = c("auto", "cpu", "gpu"),
   verbose = TRUE,
+  chunksize = 5000,
   ...
 )
 
@@ -43,6 +44,7 @@ SpaNorm(
   overwrite = FALSE,
   backend = c("auto", "cpu", "gpu"),
   verbose = TRUE,
+  chunksize = 5000,
   ...
 )
 
@@ -63,6 +65,7 @@ SpaNorm(
   overwrite = FALSE,
   backend = c("auto", "cpu", "gpu"),
   verbose = TRUE,
+  chunksize = 5000,
   ...
 )
 }
@@ -98,6 +101,8 @@ SpaNorm(
 \item{backend}{a character, specifying the backend to use for computations (default 'auto', see details). If 'gpu', GPU-based computations are used if available, otherwise CPU-based computations are used.}
 
 \item{verbose}{a logical, specifying whether to show update messages (default TRUE).}
+
+\item{chunksize}{a numeric, specifying the number of genes to process in each chunk when normalising data, only applies to logpac (default is 5000).}
 
 \item{...}{other parameters fitting parameters.}
 }


### PR DESCRIPTION
Original implementation of normaliseLogPAC converts input data to a dense matrix, which causes memory spike when dealing with large dataset like VisiumHD/Xenium,etc. This pull request add chunk processing option for logpac to process the data by chunk, which reduces memory usage. 